### PR TITLE
Remove invalid main entry point from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "type": "module",
   "version": "0.0.8",
   "description": "create an agent",
-  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary

Removes the `"main": "index.js"` field from `package.json` since the file doesn't exist.

## Changes

- Removed invalid `main` field reference

## Rationale

This is primarily a CLI tool, so the `bin` field is sufficient for npm to expose the `create-agent` command. The `main` field is only needed for programmatic imports, which aren't currently supported.

Fixes #1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the invalid `main` entry from `package.json`, leaving the CLI exposed solely via the `bin` field.
> 
> - Deletes `"main": "index.js"` from `package.json` to prevent broken module entry point
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf0aebfc1bf96d42651c81abc0e2a53f9d0405d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->