### PR TITLE
Add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # create-agent 🤖
 
+[![npm version](https://img.shields.io/npm/v/create-agent.svg)](https://www.npmjs.com/package/create-agent)
+
 A command-line tool to generate Agent keypairs with various encodings.
 
 ## Installation 📦


### PR DESCRIPTION
## Summary

Adds an npm version badge to the README header.

## Changes

Added badge that:
- Displays current npm version
- Links to the npm package page

![badge preview](https://img.shields.io/npm/v/create-agent.svg)

Fixes #5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs**
> 
> - Adds an npm version badge to the top of `README.md` showing the current published version and linking to the package on npm
> - No code or functionality changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0428660c58c26f5ba3b1173d28620542ae701876. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->