### PR TITLE
Export functions for programmatic use

### DIFF
--- a/bin/create-agent.js
+++ b/bin/create-agent.js
@@ -1,48 +1,9 @@
 #!/usr/bin/env node
 
-// =============================================================================
-// NOSTR KEY GENERATION
-// =============================================================================
-import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
-import { nip19 } from 'nostr-tools';
+import { generateAgent } from '../index.js'
 
-// Generate cryptographically secure private key (32 bytes)
-const privkey = generateSecretKey();
-const privkeyHex = Array.from(privkey)
-  .map(b => b.toString(16).padStart(2, '0'))
-  .join('');
-
-// Derive public key using Schnorr signatures (32 bytes, hex encoded)
-const pubkey = getPublicKey(privkey);
-
-// Encode keys in Nostr formats
-const nsec = nip19.nsecEncode(privkey);
-const npub = nip19.npubEncode(pubkey);
-
-// =============================================================================
-// DID DOCUMENT CREATION
-// =============================================================================
-const didDocument = {
-  "@context": [
-    "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/nostr/context"
-  ],
-  "id": `did:nostr:${pubkey}`,
-  "verificationMethod": [
-    {
-      "id": `did:nostr:${pubkey}#key1`,
-      "controller": `did:nostr:${pubkey}`,
-      "type": "SchnorrVerification2025"
-    }
-  ],
-  "authentication": [
-    "#key1"
-  ],
-  "assertionMethod": [
-    "#key1"
-  ],
-  "service": []  // Empty services array
-};
+// Generate agent identity
+const { privkey, pubkey, nsec, npub, did } = generateAgent()
 
 // =============================================================================
 // CONSOLE OUTPUT
@@ -59,7 +20,7 @@ process.stderr.write('\n\x1b[32m📋 Your Nostr Identity:\x1b[0m\n');
 process.stderr.write('\x1b[32m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n');
 process.stderr.write(`\x1b[0mPublic Key (hex) : \x1b[33m${pubkey}\x1b[0m\n`);
 process.stderr.write(`\x1b[0mNostr Public Key : \x1b[33m${npub}\x1b[0m\n`);
-process.stderr.write(`\x1b[0mPrivate Key (hex): \x1b[31m${privkeyHex}\x1b[0m\n`);
+process.stderr.write(`\x1b[0mPrivate Key (hex): \x1b[31m${privkey}\x1b[0m\n`);
 process.stderr.write(`\x1b[0mNostr Secret Key : \x1b[31m${nsec}\x1b[0m\n`);
 process.stderr.write('\n');
 process.stderr.write('\x1b[36m🔍 Usage:\x1b[0m\n');
@@ -72,5 +33,5 @@ process.stderr.write('\n');
 // Then output the DID document to stdout with a clear header in the output
 process.stderr.write('\x1b[36m📄 DID Nostr Document:\x1b[0m\n');
 process.stderr.write('\x1b[36m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n');
-console.log(JSON.stringify(didDocument, null, 2));
+console.log(JSON.stringify(did, null, 2));
 process.stderr.write('\x1b[36m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n');

--- a/index.js
+++ b/index.js
@@ -1,0 +1,42 @@
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { nip19 } from 'nostr-tools'
+
+/**
+ * Generate a new Nostr agent identity
+ * @returns {{ privkey: string, pubkey: string, nsec: string, npub: string, did: object }}
+ */
+export function generateAgent() {
+  // Generate cryptographically secure private key (32 bytes)
+  const sk = generateSecretKey()
+  const privkey = Array.from(sk)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  // Derive public key using Schnorr signatures
+  const pubkey = getPublicKey(sk)
+
+  // Encode keys in Nostr formats
+  const nsec = nip19.nsecEncode(sk)
+  const npub = nip19.npubEncode(pubkey)
+
+  // Create DID document
+  const did = {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/nostr/context"
+    ],
+    "id": `did:nostr:${pubkey}`,
+    "verificationMethod": [
+      {
+        "id": `did:nostr:${pubkey}#key1`,
+        "controller": `did:nostr:${pubkey}`,
+        "type": "SchnorrVerification2025"
+      }
+    ],
+    "authentication": ["#key1"],
+    "assertionMethod": ["#key1"],
+    "service": []
+  }
+
+  return { privkey, pubkey, nsec, npub, did }
+}


### PR DESCRIPTION
## Summary

Adds a `generateAgent()` function export, enabling programmatic use of the package.

## Changes

- Created `index.js` with exported `generateAgent()` function
- Refactored `bin/create-agent.js` to use the shared function
- CLI functionality unchanged

## New API

```js
import { generateAgent } from 'create-agent'

const { privkey, pubkey, nsec, npub, did } = generateAgent()
```

## Test Plan

- [x] CLI works: `node bin/create-agent.js`
- [x] Import works: `import { generateAgent } from './index.js'`

Fixes #7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a shared generator for Nostr identities and refactors the CLI to use it.
> 
> - Adds `index.js` exporting `generateAgent()` to produce `privkey`, `pubkey`, `nsec`, `npub`, and a DID document
> - Updates `bin/create-agent.js` to import/use `generateAgent()`, remove inline key/DID logic, and print `did` JSON while keeping CLI output/behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a210529cd293b90fb004b5a8fe5ab336ea955498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->