### PR TITLE
Add test suite

### DIFF
--- a/bin/create-agent.js
+++ b/bin/create-agent.js
@@ -1,48 +1,9 @@
 #!/usr/bin/env node
 
-// =============================================================================
-// NOSTR KEY GENERATION
-// =============================================================================
-import { generateSecretKey, getPublicKey } from 'nostr-tools/pure';
-import { nip19 } from 'nostr-tools';
+import { generateAgent } from '../index.js'
 
-// Generate cryptographically secure private key (32 bytes)
-const privkey = generateSecretKey();
-const privkeyHex = Array.from(privkey)
-  .map(b => b.toString(16).padStart(2, '0'))
-  .join('');
-
-// Derive public key using Schnorr signatures (32 bytes, hex encoded)
-const pubkey = getPublicKey(privkey);
-
-// Encode keys in Nostr formats
-const nsec = nip19.nsecEncode(privkey);
-const npub = nip19.npubEncode(pubkey);
-
-// =============================================================================
-// DID DOCUMENT CREATION
-// =============================================================================
-const didDocument = {
-  "@context": [
-    "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/nostr/context"
-  ],
-  "id": `did:nostr:${pubkey}`,
-  "verificationMethod": [
-    {
-      "id": `did:nostr:${pubkey}#key1`,
-      "controller": `did:nostr:${pubkey}`,
-      "type": "SchnorrVerification2025"
-    }
-  ],
-  "authentication": [
-    "#key1"
-  ],
-  "assertionMethod": [
-    "#key1"
-  ],
-  "service": []  // Empty services array
-};
+// Generate agent identity
+const { privkey, pubkey, nsec, npub, did } = generateAgent()
 
 // =============================================================================
 // CONSOLE OUTPUT
@@ -59,7 +20,7 @@ process.stderr.write('\n\x1b[32m📋 Your Nostr Identity:\x1b[0m\n');
 process.stderr.write('\x1b[32m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n');
 process.stderr.write(`\x1b[0mPublic Key (hex) : \x1b[33m${pubkey}\x1b[0m\n`);
 process.stderr.write(`\x1b[0mNostr Public Key : \x1b[33m${npub}\x1b[0m\n`);
-process.stderr.write(`\x1b[0mPrivate Key (hex): \x1b[31m${privkeyHex}\x1b[0m\n`);
+process.stderr.write(`\x1b[0mPrivate Key (hex): \x1b[31m${privkey}\x1b[0m\n`);
 process.stderr.write(`\x1b[0mNostr Secret Key : \x1b[31m${nsec}\x1b[0m\n`);
 process.stderr.write('\n');
 process.stderr.write('\x1b[36m🔍 Usage:\x1b[0m\n');
@@ -72,5 +33,5 @@ process.stderr.write('\n');
 // Then output the DID document to stdout with a clear header in the output
 process.stderr.write('\x1b[36m📄 DID Nostr Document:\x1b[0m\n');
 process.stderr.write('\x1b[36m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n');
-console.log(JSON.stringify(didDocument, null, 2));
+console.log(JSON.stringify(did, null, 2));
 process.stderr.write('\x1b[36m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\x1b[0m\n');

--- a/index.js
+++ b/index.js
@@ -1,0 +1,42 @@
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import { nip19 } from 'nostr-tools'
+
+/**
+ * Generate a new Nostr agent identity
+ * @returns {{ privkey: string, pubkey: string, nsec: string, npub: string, did: object }}
+ */
+export function generateAgent() {
+  // Generate cryptographically secure private key (32 bytes)
+  const sk = generateSecretKey()
+  const privkey = Array.from(sk)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+
+  // Derive public key using Schnorr signatures
+  const pubkey = getPublicKey(sk)
+
+  // Encode keys in Nostr formats
+  const nsec = nip19.nsecEncode(sk)
+  const npub = nip19.npubEncode(pubkey)
+
+  // Create DID document
+  const did = {
+    "@context": [
+      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/nostr/context"
+    ],
+    "id": `did:nostr:${pubkey}`,
+    "verificationMethod": [
+      {
+        "id": `did:nostr:${pubkey}#key1`,
+        "controller": `did:nostr:${pubkey}`,
+        "type": "SchnorrVerification2025"
+      }
+    ],
+    "authentication": ["#key1"],
+    "assertionMethod": ["#key1"],
+    "service": []
+  }
+
+  return { privkey, pubkey, nsec, npub, did }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "create an agent",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "bin": {
     "create-agent": "bin/create-agent.js"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,66 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert'
+import { generateAgent } from '../index.js'
+
+describe('generateAgent', () => {
+  test('returns all expected properties', () => {
+    const agent = generateAgent()
+    
+    assert.ok(agent.privkey, 'should have privkey')
+    assert.ok(agent.pubkey, 'should have pubkey')
+    assert.ok(agent.nsec, 'should have nsec')
+    assert.ok(agent.npub, 'should have npub')
+    assert.ok(agent.did, 'should have did')
+  })
+
+  test('privkey is 64-character hex string', () => {
+    const { privkey } = generateAgent()
+    
+    assert.strictEqual(privkey.length, 64)
+    assert.match(privkey, /^[0-9a-f]{64}$/)
+  })
+
+  test('pubkey is 64-character hex string', () => {
+    const { pubkey } = generateAgent()
+    
+    assert.strictEqual(pubkey.length, 64)
+    assert.match(pubkey, /^[0-9a-f]{64}$/)
+  })
+
+  test('nsec starts with nsec1', () => {
+    const { nsec } = generateAgent()
+    
+    assert.ok(nsec.startsWith('nsec1'))
+  })
+
+  test('npub starts with npub1', () => {
+    const { npub } = generateAgent()
+    
+    assert.ok(npub.startsWith('npub1'))
+  })
+
+  test('did document has correct structure', () => {
+    const { did, pubkey } = generateAgent()
+    
+    assert.deepStrictEqual(did['@context'], [
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/nostr/context'
+    ])
+    assert.strictEqual(did.id, `did:nostr:${pubkey}`)
+    assert.ok(Array.isArray(did.verificationMethod))
+    assert.strictEqual(did.verificationMethod[0].type, 'SchnorrVerification2025')
+    assert.deepStrictEqual(did.authentication, ['#key1'])
+    assert.deepStrictEqual(did.assertionMethod, ['#key1'])
+    assert.deepStrictEqual(did.service, [])
+  })
+
+  test('generates unique keys on each call', () => {
+    const agent1 = generateAgent()
+    const agent2 = generateAgent()
+    
+    assert.notStrictEqual(agent1.privkey, agent2.privkey)
+    assert.notStrictEqual(agent1.pubkey, agent2.pubkey)
+    assert.notStrictEqual(agent1.nsec, agent2.nsec)
+    assert.notStrictEqual(agent1.npub, agent2.npub)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a test suite using Node.js built-in test runner (zero dependencies).

## Tests

| Test | Description |
|------|-------------|
| returns all expected properties | Verifies privkey, pubkey, nsec, npub, did exist |
| privkey is 64-character hex string | Validates private key format |
| pubkey is 64-character hex string | Validates public key format |
| nsec starts with nsec1 | Verifies Nostr secret key encoding |
| npub starts with npub1 | Verifies Nostr public key encoding |
| did document has correct structure | Validates W3C DID document |
| generates unique keys on each call | Ensures cryptographic randomness |

## Running Tests

```bash
npm test
```

## Output

```
▶ generateAgent
  ✔ returns all expected properties
  ✔ privkey is 64-character hex string
  ✔ pubkey is 64-character hex string
  ✔ nsec starts with nsec1
  ✔ npub starts with npub1
  ✔ did document has correct structure
  ✔ generates unique keys on each call
✔ generateAgent

ℹ tests 7
ℹ pass 7
```

**Note:** This PR is based on #8 (programmatic exports) and should be merged after it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable identity generator and adds tests.
> 
> - Adds `index.js` exporting `generateAgent()` that returns `privkey`, `pubkey`, `nsec`, `npub`, and a DID document
> - Refactors `bin/create-agent.js` to use `generateAgent()` and print `did` and hex `privkey` directly
> - Adds `test/index.test.js` using Node’s built-in runner to validate key formats, DID structure, and uniqueness
> - Updates `package.json` test script to `node --test`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 696d8207cbd6ec3cd683022fd1ad7b656aff249f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->