### PR TITLE
Align DID document with did:nostr specification

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ export function generateAgent() {
   const nsec = nip19.nsecEncode(sk)
   const npub = nip19.npubEncode(pubkey)
 
-  // Create publicKeyMultibase: f (base16-lower) + e701 (secp256k1-pub) + 02 (even parity) + pubkey
-  const publicKeyMultibase = `f01e70202${pubkey}`
+  // Create publicKeyMultibase: f (base16-lower) + e701 (secp256k1-pub varint) + 02 (even parity) + pubkey
+  const publicKeyMultibase = `fe70102${pubkey}`
 
   // Create DID document per https://nostrcg.github.io/did-nostr/
   const did = {

--- a/index.js
+++ b/index.js
@@ -19,18 +19,23 @@ export function generateAgent() {
   const nsec = nip19.nsecEncode(sk)
   const npub = nip19.npubEncode(pubkey)
 
-  // Create DID document
+  // Create publicKeyMultibase: f (base16-lower) + e701 (secp256k1-pub) + 02 (even parity) + pubkey
+  const publicKeyMultibase = `f01e70202${pubkey}`
+
+  // Create DID document per https://nostrcg.github.io/did-nostr/
   const did = {
     "@context": [
-      "https://www.w3.org/ns/did/v1",
+      "https://w3id.org/did",
       "https://w3id.org/nostr/context"
     ],
     "id": `did:nostr:${pubkey}`,
+    "type": "DIDNostr",
     "verificationMethod": [
       {
         "id": `did:nostr:${pubkey}#key1`,
+        "type": "Multikey",
         "controller": `did:nostr:${pubkey}`,
-        "type": "SchnorrVerification2025"
+        "publicKeyMultibase": publicKeyMultibase
       }
     ],
     "authentication": ["#key1"],


### PR DESCRIPTION
## Summary

Updates the generated DID document to comply with the [did:nostr specification](https://nostrcg.github.io/did-nostr/).

## Changes

| Field | Before | After |
|-------|--------|-------|
| `@context[0]` | `https://www.w3.org/ns/did/v1` | `https://w3id.org/did` |
| `type` | *(missing)* | `"DIDNostr"` |
| `verificationMethod.type` | `"SchnorrVerification2025"` | `"Multikey"` |
| `publicKeyMultibase` | *(missing)* | `f01e70202<pubkey>` |

## publicKeyMultibase Encoding

```
f        - base16-lower multibase prefix
01e702   - secp256k1-pub multicodec (varint)
02       - compressed key even parity prefix
<pubkey> - 32-byte x-coordinate
```

## Example Output

```json
{
  "@context": ["https://w3id.org/did", "https://w3id.org/nostr/context"],
  "id": "did:nostr:2329841bad116e1bf6486b53c53e5e0020f46342cde0216c799aaa81796c94d6",
  "type": "DIDNostr",
  "verificationMethod": [{
    "id": "did:nostr:2329841bad116e1bf6486b53c53e5e0020f46342cde0216c799aaa81796c94d6#key1",
    "type": "Multikey",
    "controller": "did:nostr:2329841bad116e1bf6486b53c53e5e0020f46342cde0216c799aaa81796c94d6",
    "publicKeyMultibase": "f01e702022329841bad116e1bf6486b53c53e5e0020f46342cde0216c799aaa81796c94d6"
  }],
  "authentication": ["#key1"],
  "assertionMethod": ["#key1"],
  "service": []
}
```

Fixes #10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Brings the generated DID document into compliance with the did:nostr spec.
> 
> - Updates `@context[0]` to `https://w3id.org/did` and adds top-level `type: "DIDNostr"`
> - Replaces `verificationMethod.type` with `"Multikey"` and adds `publicKeyMultibase`
> - Computes `publicKeyMultibase` as `f` + `e701` (secp256k1-pub varint) + `02` (even parity) + `pubkey` and includes it in the DID document
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9628028cb260908a36ccb5e4e7fc21b04ea2d3c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->