### PR TITLE
Use the CID v1.0 `@context` so `Multikey` is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export function generateAgent() {
   // Create DID document per https://nostrcg.github.io/did-nostr/
   const did = {
     "@context": [
-      "https://w3id.org/did",
+      "https://www.w3.org/ns/cid/v1",
       "https://w3id.org/nostr/context"
     ],
     "id": `did:nostr:${pubkey}`,


### PR DESCRIPTION
The generated `agent.did.json` uses `"type": "Multikey"` + `publicKeyMultibase`, but those terms are not defined by the old `@context` entry `https://w3id.org/did` (which returns `text/html`, not a JSON-LD context). `Multikey`/`publicKeyMultibase` are defined only in **Controlled Identifiers v1.0** (`https://www.w3.org/ns/cid/v1`).

This swaps that one entry so the emitted document fully JSON-LD-expands:

```diff
  "@context": [
-   "https://w3id.org/did",
+   "https://www.w3.org/ns/cid/v1",
    "https://w3id.org/nostr/context"
  ]
```

Mirrors the spec change in nostrcg/did-nostr#91 (issue nostrcg/did-nostr#90). No other shape change — `DIDNostr` / `Multikey` / `publicKeyMultibase` / `#key1` are already correct. No version bump here; leaving the publish to the maintainer.