### PR TITLE
Update DID document to latest did:nostr spec (DID → CID context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The tool outputs a spec-compliant DID document to `stdout`:
 ```json
 {
   "@context": [
-    "https://w3id.org/did",
+    "https://www.w3.org/ns/cid/v1",
     "https://w3id.org/nostr/context"
   ],
   "id": "did:nostr:dd82687ee5a352c6d6de337bce53f150ca1567f3861475c74e7da62695931d23",

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ export function generateAgent() {
   // Create DID document per https://nostrcg.github.io/did-nostr/
   const did = {
     "@context": [
-      "https://w3id.org/did",
+      "https://www.w3.org/ns/cid/v1",
       "https://w3id.org/nostr/context"
     ],
     "id": `did:nostr:${pubkey}`,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -43,12 +43,12 @@ describe('generateAgent', () => {
     const { did, pubkey } = generateAgent()
     
     assert.deepStrictEqual(did['@context'], [
-      'https://www.w3.org/ns/did/v1',
+      'https://www.w3.org/ns/cid/v1',
       'https://w3id.org/nostr/context'
     ])
     assert.strictEqual(did.id, `did:nostr:${pubkey}`)
     assert.ok(Array.isArray(did.verificationMethod))
-    assert.strictEqual(did.verificationMethod[0].type, 'SchnorrVerification2025')
+    assert.strictEqual(did.verificationMethod[0].type, 'Multikey')
     assert.deepStrictEqual(did.authentication, ['#key1'])
     assert.deepStrictEqual(did.assertionMethod, ['#key1'])
     assert.deepStrictEqual(did.service, [])


### PR DESCRIPTION
## Summary

Brings the generated DID document in line with the latest [did:nostr spec](https://nostrcg.github.io/did-nostr/). The spec moved off the old **DID** context onto the **CID (Controlled Identifiers v1.0)** context, which now defines `Multikey` / `publicKeyMultibase`.

## Changes

| Field | Before | After |
|---|---|---|
| `@context[0]` (`index.js`, `README.md`) | `https://w3id.org/did` | `https://www.w3.org/ns/cid/v1` |
| `@context[0]` (test) | `https://www.w3.org/ns/did/v1` | `https://www.w3.org/ns/cid/v1` |
| verificationMethod `type` (test) | `SchnorrVerification2025` | `Multikey` |

The test assertions had drifted from the actual generated output; they're now aligned with the canonical spec example.

## Verified against spec (unchanged, already correct)

- `publicKeyMultibase` = `fe70102` + pubkey
- `id: did:nostr:<pubkey>`, top-level `type: "DIDNostr"`, verificationMethod `type: "Multikey"`
- `authentication` / `assertionMethod` = `["#key1"]`

## Testing

`npm test` → 7/7 pass.

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)