### PR TITLE
Bump version to 0.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "create-agent",
-  "version": "0.0.4",
+  "version": "0.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-agent",
-      "version": "0.0.4",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
         "nostr-tools": "^2.10.4"
       },
       "bin": {
-        "create-agent": "bin/create-agent"
+        "create-agent": "bin/create-agent.js"
       }
     },
     "node_modules/@noble/ciphers": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-agent",
   "type": "module",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "create an agent",
   "scripts": {
     "test": "node --test"


### PR DESCRIPTION
Patch release. Includes the did:nostr spec alignment from #23 (DID → CID context) and syncs `package-lock.json` to the current version.